### PR TITLE
ENH: Adds id to support output caching

### DIFF
--- a/steppy/base.py
+++ b/steppy/base.py
@@ -297,9 +297,20 @@ class Step:
         Returns:
             dict: Step outputs from the ``self.transformer.fit_transform`` method
         """
-        if self.output_is_cached and not self.force_fitting:
-            logger.info('Step {} loading cached output...'.format(self.name))
-            step_output_data = self._load_output(self.exp_dir_cache_step)
+        exp_dir_cache_step = self.exp_dir_cache_step
+        if 'id' in data:
+            exp_dir_cache_step = '{}__{}'.format(
+                exp_dir_cache_step, data['id'])
+
+        if os.path.exists(exp_dir_cache_step) and not self.force_fitting:
+            if 'id' in data:
+                logger.info(
+                    'Step {} loading cached output with '
+                    'id {}...'.format(self.name, data['id']))
+            else:
+                logger.info(
+                    'Step {} loading cached output...'.format(self.name))
+            step_output_data = self._load_output(exp_dir_cache_step)
         elif self.output_is_persisted and self.load_persisted_output and not self.force_fitting:
             logger.info('Step {} loading persisted output...'.format(self.name))
             step_output_data = self._load_output(self.exp_dir_outputs_step)
@@ -316,6 +327,8 @@ class Step:
                 step_inputs = self._adapt(step_inputs)
             else:
                 step_inputs = self._unpack(step_inputs)
+            if 'id' in data:
+                step_inputs['id'] = data['id']
             step_output_data = self._cached_fit_transform(step_inputs)
         return step_output_data
 
@@ -344,9 +357,19 @@ class Step:
         Returns:
             dict: step outputs from the transformer.transform method
         """
-        if self.output_is_cached:
-            logger.info('Step {} loading cached output...'.format(self.name))
-            step_output_data = self._load_output(self.exp_dir_cache_step)
+        exp_dir_cache_step = self.exp_dir_cache_step
+        if 'id' in data:
+            exp_dir_cache_step = '{}__{}'.format(
+                exp_dir_cache_step, data['id'])
+        if os.path.exists(exp_dir_cache_step) and not self.force_fitting:
+            if 'id' in data:
+                logger.info(
+                    'Step {} loading cached output with '
+                    'id {}...'.format(self.name, data['id']))
+            else:
+                logger.info(
+                    'Step {} loading cached output...'.format(self.name))
+            step_output_data = self._load_output(exp_dir_cache_step)
         elif self.output_is_persisted and self.load_persisted_output:
             logger.info('Step {} loading persisted output...'.format(self.name))
             step_output_data = self._load_output(self.exp_dir_outputs_step)
@@ -441,9 +464,13 @@ class Step:
             self.transformer.persist(self.exp_dir_transformers_step)
 
         if self.cache_output:
+            exp_dir_cache_step = self.exp_dir_cache_step
+            if 'id' in step_inputs:
+                exp_dir_cache_step = '{}__{}'.format(
+                    exp_dir_cache_step, step_inputs['id'])
             logger.info('Step {}, caching output to the {}'
-                        .format(self.name, self.exp_dir_cache_step))
-            self._persist_output(step_output_data, self.exp_dir_cache_step)
+                        .format(self.name, exp_dir_cache_step))
+            self._persist_output(step_output_data, exp_dir_cache_step)
         if self.persist_output:
             logger.info('Step {}, persisting output to the {}'
                         .format(self.name, self.exp_dir_outputs_step))
@@ -467,9 +494,13 @@ class Step:
         else:
             raise ValueError('No transformer cached {}'.format(self.name))
         if self.cache_output:
+            exp_dir_cache_step = self.exp_dir_cache_step
+            if 'id' in step_inputs:
+                exp_dir_cache_step = '{}__{}'.format(
+                    exp_dir_cache_step, step_inputs['id'])
             logger.info('Step {}, caching output to the {}'
-                        .format(self.name, self.exp_dir_cache_step))
-            self._persist_output(step_output_data, self.exp_dir_cache_step)
+                        .format(self.name, exp_dir_cache_step))
+            self._persist_output(step_output_data, exp_dir_cache_step)
         if self.persist_output:
             logger.info('Step {}, persisting output to the {}'
                         .format(self.name, self.exp_dir_outputs_step))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -99,3 +99,45 @@ def test_step_with_adapted_inputs(data):
     }
     assert output == expected
 
+
+def test_cache_output_without_id(data, tmpdir, monkeypatch):
+    exp_dir = tmpdir.mkdir("exp_dir")
+
+    step = Step(
+        name='test_cache_output_with_key',
+        transformer=IdentityOperation(),
+        input_data=['input_1'],
+        experiment_directory=str(exp_dir),
+        cache_output=True
+    )
+
+    step.fit_transform(data)
+    cache_path = exp_dir / 'cache' / step.name
+    assert cache_path.exists()
+
+
+def test_cache_output_with_id(tmpdir, monkeypatch):
+    exp_dir = tmpdir.mkdir("exp_dir")
+
+    data_train = {
+        'id': 'data_train',
+        'input': {
+            'features': np.array([
+                [1, 6],
+                [2, 5],
+                [3, 4]
+            ]),
+            'labels': np.array([2, 5, 3]),
+        }
+    }
+    step = Step(
+        name='test_cache_output_with_key',
+        transformer=IdentityOperation(),
+        input_data=['input'],
+        experiment_directory=str(exp_dir),
+        cache_output=True
+    )
+
+    step.fit_transform(data_train)
+    cache_path = exp_dir / 'cache' / step.name + '__data_train'
+    assert cache_path.exists()


### PR DESCRIPTION
Fixes https://github.com/neptune-ml/steppy/issues/39

This PR adds an optional `id` field to data dictionary. When `cache_output` is set to `True`, the`id` field is appended to `step.name`to distinguish between output caches produced by different data dictionaries.

For example:

```python
data_train = {
    'id': 'data_train'
    'input': {
        'features': np.array([
            [1, 6],
            [2, 5],
            [3, 4]
        ]),
        'labels': np.array([2, 5, 3]),
    }
}
step = Step(
    name='test_cache_output_with_key',
    transformer=IdentityOperation(),
    input_data=['input'],
    experiment_directory='/exp_dir',
    cache_output=True
)
step.fit_transform(data_train)
```

This will produce a output cache file at `/exp_dir/cache/test_cache_output_with_key__data_train`.